### PR TITLE
Add Redis to Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: "node_js"
 node_js:
   - "0.10"
+services:
+  - redis-server
 before_script:
   - sudo apt-get install -qq graphicsmagick
   - cp ./conf/envDefault.js ./conf/envLocal.js


### PR DESCRIPTION
Fixes "error event - 127.0.0.1:6379 - Error: Redis connection to 127.0.0.1:6379 failed - connect ECONNREFUSED" in Travis CI
