### PR TITLE
use bcrypt for password hashing

### DIFF
--- a/app/models/user.js
+++ b/app/models/user.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var Promise = require('bluebird')
+  , crypto = Promise.promisifyAll(require('crypto'))
   , uuid = require('uuid')
   , config = require('../../config/config').load()
   , inherits = require("util").inherits

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -147,7 +147,7 @@ exports.addModel = function(database) {
   }
 
   User.prototype.validPassword = function(clearPassword) {
-    return bcrypt.compareAsync(clearPassword, this.hashedPassword);
+    return bcrypt.compareAsync(clearPassword, this.hashedPassword)
   }
 
   User.prototype.isValidEmail = function() {
@@ -198,10 +198,10 @@ exports.addModel = function(database) {
       that.validateOnCreate()
         .then(function(user) {
           if (_.isFunction(user.hashedPassword)) {
-            var pwd = user.hashedPassword();
-            return user.updatePassword(pwd, pwd);
+            var pwd = user.hashedPassword()
+            return user.updatePassword(pwd, pwd)
           } else {
-            resolve(user);
+            resolve(user)
           }
         })
         .then(function(user) {
@@ -274,9 +274,9 @@ exports.addModel = function(database) {
         reject(new Error("Password do not match"))
       } else {
         bcrypt.hashAsync(password, 10)
-          .then(function(hashed_password) {
-            that.hashedPassword = hashed_password
-            return that;
+          .then(function(hashedPassword) {
+            that.hashedPassword = hashedPassword
+            return that
           })
           .then(function(user) {
             database.hmsetAsync(mkKey(['user', user.id]),

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -13,7 +13,7 @@ var Promise = require('bluebird')
   , mkKey = require("../support/models").mkKey
   , _ = require('lodash')
   , validator = require('validator')
-  , bcrypt = require('bcrypt-then')
+  , bcrypt = Promise.promisifyAll(require('bcrypt'))
 
 exports.addModel = function(database) {
   /**
@@ -147,7 +147,7 @@ exports.addModel = function(database) {
   }
 
   User.prototype.validPassword = function(clearPassword) {
-    return bcrypt.compare(clearPassword, this.hashedPassword);
+    return bcrypt.compareAsync(clearPassword, this.hashedPassword);
   }
 
   User.prototype.isValidEmail = function() {
@@ -273,7 +273,7 @@ exports.addModel = function(database) {
       } else if (password !== passwordConfirmation) {
         reject(new Error("Password do not match"))
       } else {
-        bcrypt.hash(password)
+        bcrypt.hashAsync(password, 10)
           .then(function(hashed_password) {
             that.hashedPassword = hashed_password
             return that;

--- a/config/environments/development.js
+++ b/config/environments/development.js
@@ -5,7 +5,6 @@ exports.getConfig = function() {
     port: 3000,
     database: 2,
 
-    saltSecret: 'secret token',
     secret: 'secret',
 
     origin: 'http://localhost:3333',

--- a/config/environments/test.js
+++ b/config/environments/test.js
@@ -5,7 +5,6 @@ exports.getConfig = function() {
     port: 31337,
     database: 3,
 
-    saltSecret: 'secret token',
     secret: 'secret',
 
     origin: 'http://localhost:3333'

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "method-override": "2.3.2",
     "socket.io": "1.3.5",
     "socket.io-redis": "0.1.4",
-    "validator": "3.37.0"
+    "validator": "3.37.0",
+    "bcrypt-then": "1.0.0"
   },
   "devDependencies": {
     "mkdirp": "0.5.0"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "socket.io": "1.3.5",
     "socket.io-redis": "0.1.4",
     "validator": "3.37.0",
-    "bcrypt-then": "1.0.0"
+    "bcrypt": "0.8.2"
   },
   "devDependencies": {
     "mkdirp": "0.5.0"

--- a/test/functional/session.js
+++ b/test/functional/session.js
@@ -7,14 +7,14 @@ describe("SessionController", function() {
   beforeEach(funcTestHelper.flushDb())
 
   describe("#create()", function() {
-    var user, user_data;
+    var user, userData;
 
     beforeEach(function(done) {
-      user_data = {
+      userData = {
         username: 'Luna',
         password: 'password'
-      };
-      user = new models.User(user_data)
+      }
+      user = new models.User(userData)
 
       user.create()
         .then(function(newUser) { done() })
@@ -23,7 +23,7 @@ describe("SessionController", function() {
     it("should sign in with a valid user", function(done) {
       request
         .post(app.config.host + '/v1/session')
-        .send({ username: user_data.username, password: user_data.password })
+        .send({ username: userData.username, password: userData.password })
         .end(function(err, res) {
           res.should.not.be.empty
           res.body.should.not.be.empty
@@ -37,7 +37,7 @@ describe("SessionController", function() {
     it("should not sign in with an invalid user", function(done) {
       request
         .post(app.config.host + '/v1/session')
-        .send({ username: 'username', password: user_data.password })
+        .send({ username: 'username', password: userData.password })
         .end(function(err, res) {
           res.should.not.be.empty
           res.body.err.should.not.be.empty

--- a/test/functional/session.js
+++ b/test/functional/session.js
@@ -7,13 +7,14 @@ describe("SessionController", function() {
   beforeEach(funcTestHelper.flushDb())
 
   describe("#create()", function() {
-    var user
+    var user, user_data;
 
     beforeEach(function(done) {
-      user = new models.User({
+      user_data = {
         username: 'Luna',
         password: 'password'
-      })
+      };
+      user = new models.User(user_data)
 
       user.create()
         .then(function(newUser) { done() })
@@ -22,7 +23,7 @@ describe("SessionController", function() {
     it("should sign in with a valid user", function(done) {
       request
         .post(app.config.host + '/v1/session')
-        .send({ username: user.username, password: user.password })
+        .send({ username: user_data.username, password: user_data.password })
         .end(function(err, res) {
           res.should.not.be.empty
           res.body.should.not.be.empty
@@ -36,7 +37,7 @@ describe("SessionController", function() {
     it("should not sign in with an invalid user", function(done) {
       request
         .post(app.config.host + '/v1/session')
-        .send({ username: 'username', password: user.password })
+        .send({ username: 'username', password: user_data.password })
         .end(function(err, res) {
           res.should.not.be.empty
           res.body.err.should.not.be.empty

--- a/test/unit/user.js
+++ b/test/unit/user.js
@@ -216,19 +216,6 @@ describe('User', function() {
         })
     })
 
-    it('should not create empty hashed password', function(done) {
-      var user = new User({
-        username: 'Luna',
-        password: ''
-      })
-
-      user.updateHashedPassword()
-        .catch(function(e) {
-          e.message.should.eql("Password cannot be blank")
-          done()
-        })
-    })
-
     it('should not create two users with the same username', function(done) {
       var userA
         , userB


### PR DESCRIPTION
Right now, server [stores salted sha-1 hashes](https://github.com/pepyatka/pepyatka-server/blob/master/app/models/user.js#L125). That is not considered secure these days.

It would be better to use [bcrypt](https://www.npmjs.com/package/bcrypt) instead.

Usage documentation [is available here](https://github.com/ncb000gt/node.bcrypt.js#async-recommended).

Important bit regarding migration: current field can be reused. hash-upgrading can happen during the login (check hash length, if it corresponds to sha1 — verify against it and store bcrypt hash instead, otherwise just verify against bcrypt).