### PR TITLE
Fixes a defect when serializer may return dup objects in an array

### DIFF
--- a/app/serializers/abstract_serializer.js
+++ b/app/serializers/abstract_serializer.js
@@ -85,12 +85,12 @@ exports.addSerializer = function() {
       }
 
       var node = serializer ? new serializer(objects[0]).name : field
-      async.forEach(objects, function(object, done) {
+      async.eachSeries(objects, function(object, done) {
         // Does not request objects that already has been serialized
         // and they are in root.
-        var inArray = _.filter(root[node], function(item) {
+        var inArray = _.any(root[node], function(item) {
           return item.id == object.id
-        }).length > 0
+        })
 
         if (!inArray) {
           if (serializer) {


### PR DESCRIPTION
When we was going through items array we did this in parallel, so we
may hit race-conditions when root element is not updated with one of
elements we iterate resulting in dup object in root node.

Additionally changed _.filter to _.any to find out if object is
already in the root.

Rough estimate, json is ~50% optimized.