### PR TITLE
do not send subscriptions to the client (they will only be necessary …

### DIFF
--- a/app/serializers/v1/PostSerializer.js
+++ b/app/serializers/v1/PostSerializer.js
@@ -1,7 +1,6 @@
 var models = require("../../models")
   , Serializer = models.Serializer
   , UserSerializer = models.UserSerializer
-  , SubscriptionSerializer = models.SubscriptionSerializer
   , AttachmentSerializer = models.AttachmentSerializer
   , CommentSerializer = models.CommentSerializer
 
@@ -11,7 +10,6 @@ exports.addSerializer = function() {
     attachments: { through: AttachmentSerializer, embed: true },
     createdBy: { through: UserSerializer, embed: true },
     comments: { through: CommentSerializer, embed: true },
-    likes: { through: UserSerializer, embed: true },
-    subscriptions: { through: SubscriptionSerializer, embed: true }
+    likes: { through: UserSerializer, embed: true }
   })
 }


### PR DESCRIPTION
…when group support is rolled out, and the current implementation should be reworked anyway so that only relevant information is sent to the client)