### PR TITLE
Add optional statistics for Redis queries.

### DIFF
--- a/app/models.js
+++ b/app/models.js
@@ -3,6 +3,8 @@
 var redis = require('../config/database')
   , database = redis.connect()
 
+exports.database = database
+
 exports.AbstractSerializer = require('./serializers/abstract_serializer').addSerializer()
 exports.Serializer         = require("./serializers/serializer").addSerializer()
 

--- a/app/routes.js
+++ b/app/routes.js
@@ -39,6 +39,16 @@ var findUser = function(req, res, next) {
 module.exports = function(app) {
   app.use(require('express').static(__dirname + '/../public'))
 
+  app.use(function(req, res, next) {
+    if (config.redis.analyze_performance && req.method != "OPTIONS") {
+      models.database.reset_statistics()
+      req.on("end", function() {
+        models.database.report_statistics(req.originalUrl, app.logger)
+      })
+    }
+    next()
+  })
+
   app.options('/*', function(req, res) { res.status(200).send({}) })
 
   SessionRoute.addRoutes(app)

--- a/config/database.js
+++ b/config/database.js
@@ -3,11 +3,63 @@
 var Promise = require('bluebird')
   , redis = require('redis')
   , config = require('./config').load()
+  , _ = require('lodash')
 
 Promise.promisifyAll(redis.RedisClient.prototype)
 Promise.promisifyAll(redis.Multi.prototype)
 
-var database = redis.createClient(config.redis.port, config.redis.host, {})
+function isUUID(arg) {
+  return arg.length == 36 && arg[8] == '-' && arg[13] == '-' && arg[18] == '-' && arg[23] == '-'
+}
+
+function getPerformanceStatisticsKey(command, args) {
+  if (_.isString(args[0])) {
+    var commandArgs = args[0].split(":").map(function(arg) {
+      if (isUUID(arg)) {
+        return '*'
+      }
+      return arg
+    })
+    return command + " " + commandArgs.join(":")
+  }
+  return command
+}
+
+function initDb() {
+  var db = redis.createClient(config.redis.port, config.redis.host, {})
+
+  if (config.redis.analyze_performance) {
+    var old_send_command = db.send_command
+    db.send_command = function(command, args, callback) {
+      var stats = db.redis_statistics
+      if (stats) {
+        var key = getPerformanceStatisticsKey(command, args)
+        var oldCount = stats[key] || 0
+        stats[key] = oldCount + 1
+      }
+      old_send_command.apply(db, arguments)
+    }
+
+    db.reset_statistics = function() {
+      this.redis_statistics = {}
+    }
+
+    db.report_statistics = function(url, logger) {
+      if (this.redis_statistics && _.keys(this.redis_statistics).length > 0) {
+        logger.info("Statistics for " + url + ":")
+        var total = 0
+        _.forEach(this.redis_statistics, function(v, k) {
+          logger.info("  " + k + ": " + v)
+          total += v
+        })
+        logger.info("  -- TOTAL: " + total)
+      }
+    }
+  }
+  return db
+}
+
+var database = initDb()
 
 exports.selectDatabase = function() {
   return new Promise(function(resolve, reject) {
@@ -17,7 +69,7 @@ exports.selectDatabase = function() {
 }
 
 exports.connect = function() {
-  if (!database) database = redis.createClient(config.redis.port, config.redis.host, {})
+  if (!database) database = initDb()
   return database
 }
 

--- a/config/environments/development.js
+++ b/config/environments/development.js
@@ -54,7 +54,8 @@ exports.getConfig = function() {
 
   config.redis = {
     host: 'localhost',
-    port: 6379
+    port: 6379,
+    analyze_performance: true
   }
 
   return config


### PR DESCRIPTION
If config.redis.analyze_performance is enabled, log the
number and types of Redis queries executed on each
request.
