### PR TITLE
Case-insensitive file extension handling

### DIFF
--- a/app/models/attachment.js
+++ b/app/models/attachment.js
@@ -87,9 +87,9 @@ exports.addModel = function(database) {
           attachment.fileSize = attachment.file.size
           attachment.mimeType = attachment.file.type
 
-          var supportedExtensions = /\.(jpe?g|png|gif)$/
+          var supportedExtensions = /\.(jpe?g|png|gif)$/i
           if (attachment.fileName && attachment.fileName.match(supportedExtensions).length !== null) {
-            attachment.fileExtension = attachment.fileName.match(supportedExtensions)[1]
+            attachment.fileExtension = attachment.fileName.match(supportedExtensions)[1].toLowerCase()
           } else {
             attachment.fileExtension = null
           }


### PR DESCRIPTION
Исправляет ситуацию, когда файлы *.jpg загружаются нормально, а *.JPG — нет (https://freefeed.net/eugene/2c746540-2213-469a-8e43-73c16062f8cd?offset=0).
