### PR TITLE
Fix thumbnail orientation for silly browsers

### DIFF
--- a/app/models/attachment.js
+++ b/app/models/attachment.js
@@ -180,6 +180,7 @@ exports.addModel = function(database) {
               that.noThumbnail = '0'
               gm(originalPath)
                 .resize(525, 175)
+                .autoOrient()
                 .quality(95)
                 .write(that.getThumbnailPath(), function (err) {
                   if (err) {


### PR DESCRIPTION
It rotates image according to EXIF "orientation" property and then strips EXIF profile.