### PR TITLE
Faster likes

### DIFF
--- a/app/controllers/api/v1/PostsController.js
+++ b/app/controllers/api/v1/PostsController.js
@@ -128,14 +128,19 @@ exports.addController = function(app) {
     }
   }
 
-  PostsController.like = function(req, res) {
-    if (!req.user)
-      return res.status(401).jsonp({ err: 'Not found' })
+  PostsController.like = async function(req, res) {
+    if (!req.user) {
+      res.status(401).jsonp({ err: 'Not found' })
+      return
+    }
 
-    models.Post.getById(req.params.postId)
-      .then(function(post) { return post.addLike(req.user.id) })
-      .then(function() { res.status(200).send({}) })
-      .catch(exceptions.reportError(res))
+    try {
+      let post = await models.Post.getById(req.params.postId)
+      await post.addLike(req.user.id)
+      res.status(200).send({})
+    } catch(e) {
+      exceptions.reportError(res)(e)
+    }
   }
 
   PostsController.unlike = function(req, res) {

--- a/app/controllers/api/v1/PostsController.js
+++ b/app/controllers/api/v1/PostsController.js
@@ -136,7 +136,7 @@ exports.addController = function(app) {
 
     try {
       let post = await models.Post.getById(req.params.postId)
-      await post.addLike(req.user.id)
+      await post.addLike(req.user)
       res.status(200).send({})
     } catch(e) {
       exceptions.reportError(res)(e)

--- a/app/models/post.js
+++ b/app/models/post.js
@@ -599,17 +599,18 @@ exports.addModel = function(database) {
 
   Post.prototype.isPrivate = async function() {
     var timelines = await this.getPostedTo()
-    var arr = await* timelines.map(async (timeline) => {
-      var owner = await models.User.findById(timeline.userId)
 
-      if (timeline.isDirects() || owner.isPrivate === '1')
+    var arr = timelines.map(async (timeline) => {
+      if (timeline.isDirects())
         return true
 
-      // we do not have private feeds yet so user can open any
-      // post if it's not a direct message
-      return false
+      let owner = await models.User.findById(timeline.userId)
+
+      return (owner.isPrivate === '1')
     })
-    return _.every(arr, _.identity, true)
+
+    // one public timeline is enough
+    return _.every(await* arr)
   }
 
   Post.prototype.addLike = async function(userId) {

--- a/app/models/post.js
+++ b/app/models/post.js
@@ -644,7 +644,7 @@ exports.addModel = function(database) {
   Post.prototype.addLike = async function(userId) {
     var timelines = []
     var user = await models.User.findById(userId)
-    await user.validateCanLikePost(this.id)
+    await user.validateCanLikePost(this)
 
     if (!await this.isPrivate())
       timelines = await this.getLikesFriendOfFriendTimelines(userId)
@@ -654,7 +654,7 @@ exports.addModel = function(database) {
     promises.push(database.zaddAsync(mkKey(['post', this.id, 'likes']), now, userId))
     await* promises
 
-    await pubSub.newLike(this.id, userId)
+    await pubSub.newLike(this, userId)
     var stats = await models.Stats.findById(userId)
     return stats.addLike()
   }
@@ -668,7 +668,7 @@ exports.addModel = function(database) {
       models.User.findById(userId)
         .then(function(user) {
           theUser = user
-          return user.validateCanUnLikePost(that.id)
+          return user.validateCanUnLikePost(that)
         })
         .then(function() {
           return database.zremAsync(mkKey(['post', that.id, 'likes']), userId)

--- a/app/models/post.js
+++ b/app/models/post.js
@@ -264,92 +264,61 @@ exports.addModel = function(database) {
     return this.postedTo
   }
 
-  Post.prototype.getGenericFriendOfFriendTimelineIds = function(userId, type) {
-    var that = this
-    var timelineIds = []
-    var user, feeds, groupOnly
+  Post.prototype.getGenericFriendOfFriendTimelineIds = async function(user, type) {
+    let timelineIds = []
 
-    return new Promise(function(resolve, reject) {
-      models.User.findById(userId)
-        .then(function(newUser) {
-          user = newUser
-          return user['get' + type + 'Timeline']()
-        })
-        .then(function(timeline) {
-          timelineIds.push(timeline.id)
-          return timeline.getSubscribers()
-        })
-        .then(function(users) {
-          feeds = users
-          return that.getPostedToIds()
-            .then(function(postedToIds) {
-              return Promise.map(postedToIds, function(timelineId) {
-                return models.Timeline.findById(timelineId)
-                  .then(function(timeline) { return timeline.getUser() })
-                  .then(function(user) { return user.isUser() })
-              })
-            })
-        })
-        .then(function(users) {
-          // Adds the specified post to River of News if and only if
-          // that post has been published to user's Post timeline,
-          // otherwise this post will stay in group(s) timelines
-          if (_.any(users, _.identity, true)) {
-            groupOnly = false
-            return Promise.map(feeds, function(user) {
-              return user.getRiverOfNewsTimelineId()
-            })
-          } else {
-            groupOnly = true
-            return []
-          }
-        })
-        .then(function(subscribedTimelineIds) {
-          timelineIds = timelineIds.concat(subscribedTimelineIds)
-          return that.getSubscribedTimelineIds(groupOnly)
-        })
-        .then(function(subscribedTimelineIds) {
-          timelineIds = timelineIds.concat(subscribedTimelineIds)
-          return user.getRiverOfNewsTimelineId()
-        })
-        .then(function(timelineId) {
-          timelineIds.push(timelineId)
-          timelineIds = _.uniq(timelineIds)
-          resolve(timelineIds)
-        })
+    let timeline = await user['get' + type + 'Timeline']()
+    timelineIds.push(timeline.id)
+
+    let postedToIds = await this.getPostedToIds()
+
+    let userPromises = postedToIds.map(async (timelineId) => {
+      let timeline = await models.Timeline.findById(timelineId)
+      let timelineOwner = await timeline.getUser()
+
+      return timelineOwner.isUser()
     })
+
+    // Adds the specified post to River of News if and only if
+    // that post has been published to user's Post timeline,
+    // otherwise this post will stay in group(s) timelines
+    let groupOnly = true
+
+    if (_.any(await* userPromises)) {
+      groupOnly = false
+
+      let feeds = await timeline.getSubscribers()
+      timelineIds.push(...await* feeds.map(feed => feed.getRiverOfNewsTimelineId()))
+    }
+
+    timelineIds.push(...await this.getSubscribedTimelineIds(groupOnly))
+    timelineIds.push(await user.getRiverOfNewsTimelineId())
+    timelineIds = _.uniq(timelineIds)
+
+    return timelineIds
   }
 
-  Post.prototype.getGenericFriendOfFriendTimelines = function(userId, type) {
-    var that = this
+  Post.prototype.getGenericFriendOfFriendTimelines = async function(user, type) {
+    let timelineIds = await this.getGenericFriendOfFriendTimelineIds(user, type)
+    let promises = timelineIds.map(timelineId => models.Timeline.findById(timelineId))
 
-    return new Promise(function(resolve, reject) {
-      that.getGenericFriendOfFriendTimelineIds(userId, type)
-        .then(function(timelineIds) {
-          return Promise.map(timelineIds, function(timelineId) {
-            return models.Timeline.findById(timelineId)
-          })
-        })
-        .then(function(timelines) {
-          resolve(timelines)
-        })
-    })
+    return await* promises
   }
 
-  Post.prototype.getPostsFriendOfFriendTimelineIds = function(userId) {
-    return this.getGenericFriendOfFriendTimelineIds(userId, 'Posts')
+  Post.prototype.getPostsFriendOfFriendTimelineIds = function(user) {
+    return this.getGenericFriendOfFriendTimelineIds(user, 'Posts')
   }
 
-  Post.prototype.getPostsFriendOfFriendTimelines = function(userId) {
-    return this.getGenericFriendOfFriendTimelines(userId, 'Posts')
+  Post.prototype.getPostsFriendOfFriendTimelines = function(user) {
+    return this.getGenericFriendOfFriendTimelines(user, 'Posts')
   }
 
-  Post.prototype.getLikesFriendOfFriendTimelines = function(userId) {
-    return this.getGenericFriendOfFriendTimelines(userId, 'Likes')
+  Post.prototype.getLikesFriendOfFriendTimelines = function(user) {
+    return this.getGenericFriendOfFriendTimelines(user, 'Likes')
   }
 
-  Post.prototype.getCommentsFriendOfFriendTimelines = function(userId) {
-    return this.getGenericFriendOfFriendTimelines(userId, 'Comments')
+  Post.prototype.getCommentsFriendOfFriendTimelines = function(user) {
+    return this.getGenericFriendOfFriendTimelines(user, 'Comments')
   }
 
   Post.prototype.hide = function(userId) {
@@ -400,8 +369,10 @@ exports.addModel = function(database) {
     var timelines = []
     var comment = await models.Comment.findById(commentId)
 
-    if (!await this.isPrivate())
-      timelines = await this.getCommentsFriendOfFriendTimelines(comment.userId)
+    if (!await this.isPrivate()) {
+      let user = await models.User.findById(comment.userId)
+      timelines = await this.getCommentsFriendOfFriendTimelines(user)
+    }
 
     await* timelines.map((timeline) => timeline.updatePost(this.id))
     await database.rpushAsync(mkKey(['post', this.id, 'comments']), commentId)
@@ -647,7 +618,7 @@ exports.addModel = function(database) {
     await user.validateCanLikePost(this)
 
     if (!await this.isPrivate())
-      timelines = await this.getLikesFriendOfFriendTimelines(userId)
+      timelines = await this.getLikesFriendOfFriendTimelines(user)
 
     var now = new Date().getTime()
     var promises = timelines.map((timeline) => timeline.updatePost(this.id, 'like'))

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -1063,35 +1063,22 @@ exports.addModel = function(database) {
     })
   }
 
-  User.prototype.validateCanLikeOrUnlikePost = function(action, postId) {
-    var that = this
+  User.prototype.validateCanLikeOrUnlikePost = async function(action, postId) {
+    let result = await database.zscoreAsync(mkKey(['post', postId, 'likes']), this.id)
 
-    return new Promise(function(resolve, reject) {
-      return database.zscoreAsync(mkKey(['post', postId, 'likes']), that.id)
-        .then(function(result) {
-          switch (true) {
-            case result != null && action == 'like':
-              reject(new ForbiddenException("You can't like post that you have already liked"))
-              break;
-            case result == null && action == 'unlike':
-              reject(new ForbiddenException("You can't un-like post that you haven't yet liked"))
-              break;
-            default:
-              models.Post.findById(postId)
-                .then(function(post) { return post.validateCanShow(that.id) })
-                .then(function(valid) {
-                  if (valid)
-                    resolve(that)
-                  else
-                    reject(new Error("Not found"))
-                })
-              break;
-          }
-        }).catch(function(e) {
-          reject(new Error("Failed to validate like"));
-        })
-    })
+    if (result != null && action == 'like')
+      throw new ForbiddenException("You can't like post that you have already liked")
 
+    if (result == null && action == 'unlike')
+      throw new ForbiddenException("You can't un-like post that you haven't yet liked")
+
+    let post = await models.Post.findById(postId)
+    let valid = await post.validateCanShow(this.id)
+
+    if (!valid)
+      throw new Error("Not found")
+
+    return this
   }
 
   User.prototype.updateLastActivityAt = async function() {

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -1035,12 +1035,12 @@ exports.addModel = function(database) {
   }
 
   /* checks if user can like some post */
-  User.prototype.validateCanLikePost = function(postId) {
-    return this.validateCanLikeOrUnlikePost('like', postId)
+  User.prototype.validateCanLikePost = function(post) {
+    return this.validateCanLikeOrUnlikePost('like', post)
   }
 
-  User.prototype.validateCanUnLikePost = function(postId) {
-    return this.validateCanLikeOrUnlikePost('unlike', postId)
+  User.prototype.validateCanUnLikePost = function(post) {
+    return this.validateCanLikeOrUnlikePost('unlike', post)
   }
 
   User.prototype.validateCanComment = function(postId) {
@@ -1063,8 +1063,8 @@ exports.addModel = function(database) {
     })
   }
 
-  User.prototype.validateCanLikeOrUnlikePost = async function(action, postId) {
-    let result = await database.zscoreAsync(mkKey(['post', postId, 'likes']), this.id)
+  User.prototype.validateCanLikeOrUnlikePost = async function(action, post) {
+    let result = await database.zscoreAsync(mkKey(['post', post.id, 'likes']), this.id)
 
     if (result != null && action == 'like')
       throw new ForbiddenException("You can't like post that you have already liked")
@@ -1072,7 +1072,6 @@ exports.addModel = function(database) {
     if (result == null && action == 'unlike')
       throw new ForbiddenException("You can't un-like post that you haven't yet liked")
 
-    let post = await models.Post.findById(postId)
     let valid = await post.validateCanShow(this.id)
 
     if (!valid)

--- a/app/pubsub.js
+++ b/app/pubsub.js
@@ -90,8 +90,7 @@ export default class pubSub {
     await* promises
   }
 
-  async newLike(postId, userId) {
-    var post = await models.Post.findById(postId)
+  async newLike(post, userId) {
     var timelines = await post.getTimelines()
 
     var promises = timelines.map(async (timeline) => {
@@ -99,14 +98,14 @@ export default class pubSub {
       var isHidden = await post.isHiddenIn(timeline.id)
 
       if (!isHidden && !isBanned) {
-        let payload = JSON.stringify({ timelineId: timeline.id, userId: userId, postId: postId })
+        let payload = JSON.stringify({ timelineId: timeline.id, userId: userId, postId: post.id })
         await this.database.publishAsync('like:new', payload)
       }
     })
 
     await* promises
 
-    let payload = JSON.stringify({ userId: userId, postId: postId })
+    let payload = JSON.stringify({ userId: userId, postId: post.id })
     await this.database.publishAsync('like:new', payload)
   }
 

--- a/app/pubsub.js
+++ b/app/pubsub.js
@@ -52,7 +52,7 @@ export default class pubSub {
 
     var promises = timelines.map(async (timeline) => {
       let isBanned = await post.isBannedFor(timeline.userId)
-      let isHidden = await post.isHiddenIn(timeline.id)
+      let isHidden = await post.isHiddenIn(timeline)
 
       if (!isHidden && !isBanned) {
         let payload = JSON.stringify({ timelineId: timeline.id, commentId: commentId })
@@ -90,17 +90,14 @@ export default class pubSub {
     await* promises
   }
 
-  async newLike(post, userId) {
-    var timelines = await post.getTimelines()
-
+  async newLike(post, userId, timelines) {
     var promises = timelines.map(async (timeline) => {
-      var isBanned = await post.isBannedFor(timeline.userId)
-      var isHidden = await post.isHiddenIn(timeline.id)
+      // no need to notify users about updates to hidden posts
+      if (await post.isHiddenIn(timeline))
+        return
 
-      if (!isHidden && !isBanned) {
-        let payload = JSON.stringify({ timelineId: timeline.id, userId: userId, postId: post.id })
-        await this.database.publishAsync('like:new', payload)
-      }
+      let payload = JSON.stringify({ timelineId: timeline.id, userId: userId, postId: post.id })
+      await this.database.publishAsync('like:new', payload)
     })
 
     await* promises

--- a/app/routes.js
+++ b/app/routes.js
@@ -16,24 +16,23 @@ var Promise = require('bluebird')
 
 Promise.promisifyAll(jwt)
 
-var findUser = function(req, res, next) {
+var findUser = async function(req, res, next) {
   var authToken = req.headers['x-authentication-token'] ||
       req.body.authToken || req.query.authToken
-  if (authToken) {
-    var secret = config.secret
 
-    jwt.verifyAsync(authToken, secret)
-      .then(function(decoded) {
-        return models.User.findById(decoded.userId)
-      })
-      .then(function(user) {
-        if (user) req.user = user
-        next()
-      })
-      .catch(function(e) { next() })
-  } else {
-    next()
+  if (authToken) {
+    try {
+      let decoded = await jwt.verifyAsync(authToken, config.secret)
+      let user = await models.User.findById(decoded.userId)
+
+      if (user) {
+        req.user = user
+      }
+    } catch(e) {
+    }
   }
+
+  next()
 }
 
 module.exports = function(app) {

--- a/test/unit/post.js
+++ b/test/unit/post.js
@@ -322,7 +322,7 @@ describe('Post', function() {
     })
 
     it('should add like to friend of friend timelines', function(done) {
-      post.addLike(userA.id)
+      post.addLike(userA)
         .then(function(res) { return userC.getRiverOfNewsTimeline() })
         .then(function(timeline) { return timeline.getPosts() })
         .then(function(posts) {
@@ -337,7 +337,7 @@ describe('Post', function() {
     })
 
     it('should add user to likes', function(done) {
-      post.addLike(userA.id)
+      post.addLike(userA)
         .then(function(res) { return post.getLikes() })
         .then(function(users) {
           users.should.not.be.empty
@@ -393,7 +393,7 @@ describe('Post', function() {
     })
 
     it('should remove like from friend of friend timelines', function(done) {
-      post.addLike(userA.id)
+      post.addLike(userA)
         .then(function(res) { return post.removeLike(userA.id) })
         .then(function(res) { return post.getLikes() })
         .then(function(users) {
@@ -404,7 +404,7 @@ describe('Post', function() {
     })
 
     it('should add user to likes', function(done) {
-      post.addLike(userA.id)
+      post.addLike(userA)
         .then(function(res) { return post.getLikes() })
         .then(function(users) {
           users.should.not.be.empty

--- a/test/unit/post.js
+++ b/test/unit/post.js
@@ -333,6 +333,7 @@ describe('Post', function() {
           newPost.id.should.eql(post.id)
         })
         .then(function() { done() })
+        .catch(function(e) { done(e) })
     })
 
     it('should add user to likes', function(done) {
@@ -346,6 +347,7 @@ describe('Post', function() {
           user.id.should.eql(userA.id)
         })
         .then(function() { done() })
+        .catch(function(e) { done(e) })
     })
   })
 
@@ -412,6 +414,7 @@ describe('Post', function() {
           user.id.should.eql(userA.id)
         })
         .then(function() { done() })
+        .catch(function(e) { done(e) })
     })
   })
 

--- a/test/unit/user.js
+++ b/test/unit/user.js
@@ -622,6 +622,7 @@ describe('User', function() {
           newPost.id.should.eql(post.id)
           done()
         })
+        .catch(function(e) { done(e) })
     })
   })
 

--- a/test/unit/user.js
+++ b/test/unit/user.js
@@ -604,7 +604,7 @@ describe('User', function() {
           post = newPost
           return newPost.create()
         })
-        .then(function(post) { return post.addLike(user.id) })
+        .then(function(post) { return post.addLike(user) })
         .then(function() { return user.getMyDiscussionsTimeline() })
         .then(function(timeline) {
           timeline.should.be.an.instanceOf(Timeline)


### PR DESCRIPTION
This pull-request makes an attempt to:
1. minimize number of redis-requests, by propagating objects instead of ids down the call-chain
2. delay pubsub-notifications generation until regular response is sent to the user

as a side-effect, this also restores like-based propagation of hidden posts, which seemed to be absent

**NB:** _I did not do real-world speed testing yet_
