### PR TITLE
Add support for editing attachments

### DIFF
--- a/app/controllers/api/v1/PostsController.js
+++ b/app/controllers/api/v1/PostsController.js
@@ -83,7 +83,8 @@ exports.addController = function(app) {
               "You can't update another user's post"))
         }
         return post.update({
-          body: req.body.post.body
+          body: req.body.post.body,
+          attachments: req.body.post.attachments
         })
       })
       .then(function(post) {


### PR DESCRIPTION
@epicmonkey @indeyets @berkus 

Please take a look at the implementation of `unlinkAttachments()` in the change. I need a confirmation that this piece of code does a proper DB change:

```
database.lremAsync(mkKey(['post', that.id, 'attachments']), 0, attachmentId),
database.hsetAsync(mkKey(['attachment', attachmentId]), 'postId', '')
```

(as an opposite to what we do in its sister method, `linkAttachments()`).
