### PR TITLE
[attachments] Send error details when there's "Corrupt image"

### DIFF
--- a/app/controllers/api/v1/AttachmentsController.js
+++ b/app/controllers/api/v1/AttachmentsController.js
@@ -24,7 +24,13 @@ exports.addController = function(app) {
             res.jsonp(json)
           })
         })
-        .catch(function(e) { res.status(422).send({}) })
+        .catch(function(e) {
+          let errorDetails = {}
+          if (e.message && e.message.indexOf('Corrupt image') > -1) {
+            errorDetails = { message: 'Corrupt image' }
+          }
+          res.status(422).send(errorDetails)
+        })
     })
 
     form.parse(req)


### PR DESCRIPTION
When GraphicsMagick cannot parse an image (excuses vary) there's error like this:

```
gm identify: Corrupt image (/tmp/upload_3d35e6942v8e2e612e2fe5aeaea08bcv).
gm identify: Request did not return an image.
```

I want to provide client some information on what's happened, but I don't want to expose the whole text of any error (due to security reasons).
